### PR TITLE
Hold participant fix

### DIFF
--- a/serverless/functions/external-transfer/hold-conference-participant.js
+++ b/serverless/functions/external-transfer/hold-conference-participant.js
@@ -15,7 +15,8 @@ exports.handler = TokenValidator(async (context, event, callback) => {
 
   const client = context.getTwilioClient();
 
-  const participantsResponse = await client.conferences(conference)
+  const participantsResponse = await client
+    .conferences(conference)
     .participants(participant)
     .update({
       hold,
@@ -24,8 +25,8 @@ exports.handler = TokenValidator(async (context, event, callback) => {
   console.log(`Participant ${participant} updated in conference \
   ${conference}. Participant response properties:`);
 
-  Object.keys(response.body).forEach(key => {
-    console.log(`  ${key}:`, response.body[key]);
+  Object.keys(participantsResponse).forEach(key => {
+    console.log(`  ${key}:`, participantsResponse[key]);
   });
 
   callback(null, assets.response("json", participantsResponse));

--- a/src/components/ExternalTransfer/ParticipantActionsButtons.js
+++ b/src/components/ExternalTransfer/ParticipantActionsButtons.js
@@ -86,7 +86,7 @@ class ParticipantActionsButtons extends React.Component {
     const { participant, theme, task } = this.props;
 
     const holdParticipantTooltip = participant.onHold
-      ? 'Hold Participant' : 'Unhold Participant';
+      ? 'Unhold Participant' : 'Hold Participant';
     const kickParticipantTooltip = 'Remove Participant';
 
     // The name of the hold icons changed in Flex 1.11.0 to HoldOff.

--- a/src/customActions/index.js
+++ b/src/customActions/index.js
@@ -1,6 +1,7 @@
 import { Actions } from '@twilio/flex-ui';
 import { acceptInternalTask, rejectInternalTask, isInternalCall, toggleHoldInternalCall } from './internalCall';
 import { kickExternalTransferParticipant } from './externalTransfer';
+import ConferenceService from '../helpers/ConferenceService';
 
 export default (manager) => {
 
@@ -57,6 +58,32 @@ export default (manager) => {
   Actions.addListener('beforeUnholdCall', (payload) => {
     return holdCall(payload, false)
   })
+
+  Actions.addListener('beforeHoldParticipant', (payload, abortFunction) => {
+    const { participantType, targetSid: participantSid, task } = payload;
+
+    if (participantType !== 'unknown') {
+      return;
+    }
+
+    const { conferenceSid } = task.conference;
+    abortFunction();
+    console.log('Holding participant', participantSid);
+    return ConferenceService.holdParticipant(conferenceSid, participantSid);
+  });
+
+  Actions.addListener('beforeUnholdParticipant', (payload, abortFunction) => {
+    const { participantType, targetSid: participantSid, task } = payload;
+
+    if (participantType !== 'unknown') {
+      return;
+    }
+
+    const { conferenceSid } = task.conference;
+    abortFunction();
+    console.log('Holding participant', participantSid);
+    return ConferenceService.unholdParticipant(conferenceSid, participantSid);
+  });
 
 	Actions.addListener('beforeKickParticipant', (payload, abortFunction) => {
 

--- a/src/customActions/index.js
+++ b/src/customActions/index.js
@@ -79,9 +79,10 @@ export default (manager) => {
       return;
     }
 
+    console.log('Holding participant', participantSid);
+    
     const { conferenceSid } = task.conference;
     abortFunction();
-    console.log('Holding participant', participantSid);
     return ConferenceService.unholdParticipant(conferenceSid, participantSid);
   });
 

--- a/src/helpers/ConferenceService.js
+++ b/src/helpers/ConferenceService.js
@@ -11,6 +11,23 @@ class ConferenceService {
 
   manager = Manager.getInstance();
 
+  _toggleParticipantHold = (conference, participantSid, hold) => {
+    return new Promise((resolve, reject) => {
+
+      request('external-transfer/hold-conference-participant', this.manager, {
+        conference,
+        participant: participantSid,
+        hold
+      }).then(response => {
+        console.log(`${hold ? 'Hold' : 'Unhold'} successful for participant`, participantSid);
+        resolve();
+      }).catch(error => {
+        console.error(`Error ${hold ? 'holding' : 'unholding'} participant ${participantSid}\r\n`, error);
+        reject(error);
+      })
+    })
+  }
+
   setEndConferenceOnExit = (conference, participantSid, endConferenceOnExit) => {
     return new Promise((resolve, reject) => {
 
@@ -85,6 +102,14 @@ class ConferenceService {
     });
     console.log('Updating conferences:', conferences);
     dispatch({ type: 'CONFERENCE_MULTIPLE_UPDATE', payload: { conferences } });
+  }
+
+  holdParticipant = (conference, participantSid) => {
+    return this._toggleParticipantHold(conference, participantSid, true);
+  }
+
+  unholdParticipant = (conference, participantSid) => {
+    return this._toggleParticipantHold(conference, participantSid, false);
   }
 
   removeParticipant = (conference, participantSid) => {


### PR DESCRIPTION
Corrects issue with the hold/unhold button on non-customer participants always acting on the customer participant instead of the selected participant.