### PR TITLE
FLEXUI-2647: Allocate min-width for the inline hold/end button section

### DIFF
--- a/src/components/ExternalTransfer/ParticipantActionsButtons.js
+++ b/src/components/ExternalTransfer/ParticipantActionsButtons.js
@@ -10,6 +10,7 @@ import {
 } from '@twilio/flex-ui';
 
 const ActionsContainer = styled('div')`
+  min-width: 88px;
   margin-top: 10px;
   button {
       width: 36px;


### PR DESCRIPTION
## Ticket
https://issues.corp.twilio.com/browse/FLEXUI-2647

## Before
![image](https://user-images.githubusercontent.com/2273613/83153988-8069b900-a0f7-11ea-8360-13fdb9da12ba.png)

## After
![image](https://user-images.githubusercontent.com/2273613/83153971-7b0c6e80-a0f7-11ea-967a-09692974e7d9.png)
