### PR TITLE
Just show actions buttons in agent view

### DIFF
--- a/src/components/ExternalTransfer/ParticipantActionsButtons.js
+++ b/src/components/ExternalTransfer/ParticipantActionsButtons.js
@@ -119,7 +119,8 @@ class ParticipantActionsButtons extends React.Component {
   }
 
   render() {
-    return this.props.listMode
+    if (this.props.view.activeView != 'teams') {
+      return this.props.listMode
       ? (
         <ActionsContainerListItem className="ParticipantCanvas-Actions">
           {this.props.showKickConfirmation
@@ -135,17 +136,22 @@ class ParticipantActionsButtons extends React.Component {
           }
         </ActionsContainer>
       );
+    } else {
+      return (null);
+    }
   }
 }
 
 const mapStateToProps = (state, ownProps) => {
   const { participant } = ownProps;
+  const view = state.flex.view;
   const componentViewStates = state.flex.view.componentViewStates;
   const customParticipants = componentViewStates.customParticipants || {};
   const participantState = customParticipants[participant.callSid] || {};
   const customParticipantsState = {};
 
   return {
+    view,
     showKickConfirmation: participantState.showKickConfirmation,
     setShowKickConfirmation: value => {
       customParticipantsState[participant.callSid] = {


### PR DESCRIPTION
The actions buttons for end-call and put-on-hold are shown both in the agent view and in the supervisor (teams) view. Besides not functioning in the teams view, they also imply that the supervisor can end calls. That's not true.

This PR adds the `flex.view` props to the `ParticpantActionsButtons` component and checks if `currentView` is *not* teams. If it is, we don't render them.