### PR TITLE
fix(init): ensure flex dialpad is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ This feature is based on the work on this [project](https://github.com/twilio-la
 # Configuration
 
 
+## Twilio Console
+
+Ensure the Flex Native Dialpad is enabled and configured within the [Twilio Console](https://www.twilio.com/console/flex/voice).
+
 ## Flex Plugin
 
 This repository is a Flex plugin with some other assets. The following describing how you setup, develop and deploy your Flex plugin.

--- a/src/DialpadPlugin.js
+++ b/src/DialpadPlugin.js
@@ -3,6 +3,7 @@ import { FlexPlugin } from 'flex-plugin';
 import registerCustomActions from './customActions';
 import { loadExternalTransferInterface } from './components/ExternalTransfer';
 import { loadInternalCallInterface } from './components/InternalCall';
+import { NotificationType } from '@twilio/flex-ui-core';
 
 const PLUGIN_NAME = 'DialpadPlugin';
 
@@ -12,11 +13,29 @@ export default class DialpadPlugin extends FlexPlugin {
   }
 
   init(flex, manager) {
-  
-    loadExternalTransferInterface.bind(this)(flex, manager)
+    // register notification for disabled Flex Dialpad
+    flex.Notifications.registerNotification({
+      id: "dialpadNotEnabled",
+      content: "Please enable the Flex Dialpad within the Twilio Console to use the Flex Dialpad Addon Plugin",
+      type: NotificationType.error,
+      closeButton: true,
+      timeout: 0
+    })
 
-    loadInternalCallInterface.bind(this)(flex, manager)
+    try {
+      // Check for existence Flex Dialpad configuration
+      const {
+        workflow_sid,
+        queue_sid
+      } = manager.serviceConfiguration.outbound_call_flows.default;
 
-    registerCustomActions(manager);
+      loadInternalCallInterface.bind(this)(flex, manager)
+      loadExternalTransferInterface.bind(this)(flex, manager)
+      registerCustomActions(manager);
+    } catch (error) {
+      console.log('Dialpad Addon Plugin:: Flex Dialpad not Enabled')
+      flex.Notifications.showNotification('dialpadNotEnabled')
+    }
+
   }
 }


### PR DESCRIPTION
An Escalation was logged with an error related to this plugin.
- https://issues.corp.twilio.com/browse/FLEXUI-4409

The cause of the issue was related to the Flex Dialpad being disabled in the console.

### Changes:
- add try/catch checking for Flex Dialpad configuration (i.e. `outbound_call_flows` key on Flex Configuration)
- register/display notification when Flex dialpad is not enabled (i.e. `outbound_call_flows` key on Flex Configuration is null)

![2021-09-15_17-52-00](https://user-images.githubusercontent.com/7215306/133527946-94705435-76fb-4fb7-a5a6-2869f2b49e2b.png)
